### PR TITLE
Disable HTTP keep-alive to fix test hangs

### DIFF
--- a/pdp-server/src/test/java/pdp/serviceregistry/UrlResourceServiceRegistryTest.java
+++ b/pdp-server/src/test/java/pdp/serviceregistry/UrlResourceServiceRegistryTest.java
@@ -2,6 +2,7 @@ package pdp.serviceregistry;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.apache.commons.io.IOUtils;
+import org.junit.BeforeClass;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,6 +31,10 @@ public class UrlResourceServiceRegistryTest {
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(8889);
 
+    @BeforeClass
+    public static void doBeforeClass() {
+      System.setProperty("http.keepAlive", "false");
+    }
 
     @Before
     public void before() throws IOException {

--- a/pdp-server/src/test/java/pdp/teams/VootClientTest.java
+++ b/pdp-server/src/test/java/pdp/teams/VootClientTest.java
@@ -3,6 +3,7 @@ package pdp.teams;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.apache.commons.io.IOUtils;
 import org.apache.openaz.xacml.std.pip.engines.ConfigurableEngine;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.core.io.ClassPathResource;
@@ -24,6 +25,11 @@ public class VootClientTest {
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(8889);
+
+    @BeforeClass
+    public static void doBeforeClass() {
+      System.setProperty("http.keepAlive", "false");
+    }
 
     @Test
     public void testInstanceOf() throws ClassNotFoundException, IllegalAccessException, InstantiationException {


### PR DESCRIPTION
We were encountering an issue where the build process would randomly hang during tests (and fail/timeout). Looking at the Travis logs for PDP and VOOT, we noticed that it experiences a similar issue that we were having. 

`java.net.HttpURLConnection`  seems to be affected. However, VOOT seems to use the `spring` and `apache` http clients. In our testing, `spring` seems to be affected similarly to the way `java.net` is, but the `apache` client doesn't seem to be. 

After debugging, we noticed the following line would hang randomly during runs: 
https://github.com/OpenConext/OpenConext-pdp/blob/dbae56de1bfb785b24004d7766b58c0c612f30f6/pdp-server/src/main/java/pdp/serviceregistry/BasicAuthenticationUrlResource.java#L33

After these changes, we looped the testing for 12+ hours without a single test hang. Previously we would get ~1 in 4 tests hang.

Note: This only changes the client behavior during the JUnit tests and doesn't actually change the PDP  code itself. 

I hope you'll find this useful :)