### PR TITLE
fix/policy-editable

### DIFF
--- a/pdp-server/src/main/java/pdp/domain/PdpPolicy.java
+++ b/pdp-server/src/main/java/pdp/domain/PdpPolicy.java
@@ -221,6 +221,7 @@ public class PdpPolicy {
         clone.setName(newName);
         clone.setLatestRevision(true);
         clone.setUserIdentifier(userIdentifier);
+        clone.setAuthenticatingAuthority(parent.getAuthenticatingAuthority()); // TODO: is it necessary to set it?
         clone.setUserDisplayName(userDisplayName);
         clone.setActive(isActive);
         clone.setRevisionNbr(parent.getRevisions().size() + 1);

--- a/pdp-server/src/main/java/pdp/domain/PdpPolicy.java
+++ b/pdp-server/src/main/java/pdp/domain/PdpPolicy.java
@@ -221,7 +221,7 @@ public class PdpPolicy {
         clone.setName(newName);
         clone.setLatestRevision(true);
         clone.setUserIdentifier(userIdentifier);
-        clone.setAuthenticatingAuthority(parent.getAuthenticatingAuthority()); // TODO: is it necessary to set it?
+        clone.setAuthenticatingAuthority(parent.getAuthenticatingAuthority());
         clone.setUserDisplayName(userDisplayName);
         clone.setActive(isActive);
         clone.setRevisionNbr(parent.getRevisions().size() + 1);

--- a/pdp-server/src/main/java/pdp/domain/PdpPolicy.java
+++ b/pdp-server/src/main/java/pdp/domain/PdpPolicy.java
@@ -221,7 +221,6 @@ public class PdpPolicy {
         clone.setName(newName);
         clone.setLatestRevision(true);
         clone.setUserIdentifier(userIdentifier);
-        clone.setAuthenticatingAuthority(parent.getAuthenticatingAuthority());
         clone.setUserDisplayName(userDisplayName);
         clone.setActive(isActive);
         clone.setRevisionNbr(parent.getRevisions().size() + 1);

--- a/pdp-server/src/main/java/pdp/domain/PdpPolicy.java
+++ b/pdp-server/src/main/java/pdp/domain/PdpPolicy.java
@@ -212,7 +212,7 @@ public class PdpPolicy {
         this.type = type;
     }
 
-    public static PdpPolicy revision(String newName, PdpPolicy parent, String newPolicyXml, String userIdentifier, String authenticatingAuthority, String userDisplayName, boolean isActive) {
+    public static PdpPolicy revision(String newName, PdpPolicy parent, String newPolicyXml, String userIdentifier, String userDisplayName, boolean isActive) {
         parent.getRevisions().forEach(p -> p.setLatestRevision(false));
         parent.setLatestRevision(false);
 
@@ -221,7 +221,7 @@ public class PdpPolicy {
         clone.setName(newName);
         clone.setLatestRevision(true);
         clone.setUserIdentifier(userIdentifier);
-        clone.setAuthenticatingAuthority(authenticatingAuthority);
+        clone.setAuthenticatingAuthority(parent.getAuthenticatingAuthority());
         clone.setUserDisplayName(userDisplayName);
         clone.setActive(isActive);
         clone.setRevisionNbr(parent.getRevisions().size() + 1);

--- a/pdp-server/src/main/java/pdp/web/PdpController.java
+++ b/pdp-server/src/main/java/pdp/web/PdpController.java
@@ -273,7 +273,7 @@ public class PdpController implements JsonMapper, IPAddressProvider{
             policy = fromDB.getParentPolicy() != null ? fromDB.getParentPolicy() : fromDB;
             //Cascade.ALL
             PdpPolicy.revision(pdpPolicyDefinition.getName(), policy, policyXml, policyIdpAccessEnforcer.username(),
-                policyIdpAccessEnforcer.authenticatingAuthority(), policyIdpAccessEnforcer.userDisplayName(), pdpPolicyDefinition.isActive());
+                policyIdpAccessEnforcer.userDisplayName(), pdpPolicyDefinition.isActive());
         } else {
             policy = new PdpPolicy(policyXml, pdpPolicyDefinition.getName(), true, policyIdpAccessEnforcer.username(),
                 policyIdpAccessEnforcer.authenticatingAuthority(), policyIdpAccessEnforcer.userDisplayName(), pdpPolicyDefinition.isActive(),

--- a/pdp-server/src/test/java/pdp/domain/PdpPolicyTest.java
+++ b/pdp-server/src/test/java/pdp/domain/PdpPolicyTest.java
@@ -17,7 +17,7 @@ public class PdpPolicyTest implements JsonMapper {
     public void testRevision() throws Exception {
         PdpPolicy parent = new PdpPolicy();
 
-        PdpPolicy revision = PdpPolicy.revision("new policy", parent, "xml", "uid", PolicyLoader.authenticatingAuthority, "John Doe", true);
+        PdpPolicy revision = PdpPolicy.revision("new policy", parent, "xml", "uid", "John Doe", true);
 
         assertFalse(parent.isLatestRevision());
         assertEquals(1, parent.getRevisions().size());

--- a/pdp-server/src/test/java/pdp/repositories/PdpPolicyRepositoryTest.java
+++ b/pdp-server/src/test/java/pdp/repositories/PdpPolicyRepositoryTest.java
@@ -53,8 +53,8 @@ public class PdpPolicyRepositoryTest extends AbstractRepositoryTest {
     @Test
     public void testFindRevisionCountPerId() throws Exception {
         PdpPolicy policy = pdpPolicy(NAME_ID + 2);
-        PdpPolicy.revision(NAME_ID + 3, policy, "xml", "system", PolicyLoader.authenticatingAuthority, "John Doe", true);
-        PdpPolicy.revision(NAME_ID + 4, policy, "xml", "system", PolicyLoader.authenticatingAuthority, "John Doe", true);
+        PdpPolicy.revision(NAME_ID + 3, policy, "xml", "system", "John Doe", true);
+        PdpPolicy.revision(NAME_ID + 4, policy, "xml", "system", "John Doe", true);
         pdpPolicyRepository.save(policy);
 
         PdpPolicy latestRevision = pdpPolicyRepository.findFirstByPolicyIdAndLatestRevision(getPolicyId(NAME_ID + 4), true).get();


### PR DESCRIPTION
revision uses parent.getAuthenticatingAuthority instead of using the new authenticatingAuthority