### PR TITLE
Pt adaptation

### DIFF
--- a/pdp-server/src/main/java/pdp/domain/PdpPolicyDefinition.java
+++ b/pdp-server/src/main/java/pdp/domain/PdpPolicyDefinition.java
@@ -41,12 +41,14 @@ public class PdpPolicyDefinition {
     private String serviceProviderId;
     private String serviceProviderName;
     private String serviceProviderNameNl;
+    private String serviceProviderNamePt;
 
     private boolean serviceProviderInvalidOrMissing;
 
     private List<String> identityProviderIds = new ArrayList<>();
     private List<String> identityProviderNames = new ArrayList<>();
     private List<String> identityProviderNamesNl = new ArrayList<>();
+    private List<String> identityProviderNamesPt = new ArrayList<>();
 
     private String clientId;
 
@@ -74,6 +76,7 @@ public class PdpPolicyDefinition {
     private int numberOfRevisions;
 
     private String denyAdviceNl;
+    private String denyAdvicePt;
 
     private int revisionNbr;
 
@@ -203,6 +206,16 @@ public class PdpPolicyDefinition {
         this.identityProviderNamesNl = identityProviderNamesNl;
     }
 
+    public List<String> getIdentityProviderNamesPt() {
+        return identityProviderNamesPt;
+    }
+
+    public void setIdentityProviderNamesPt(List<String> identityProviderNamesPt) {
+        this.identityProviderNamesPt = identityProviderNamesPt;
+    }
+
+
+
     public int getNumberOfViolations() {
         return numberOfViolations;
     }
@@ -218,6 +231,18 @@ public class PdpPolicyDefinition {
     public String getDenyAdviceNl() {
         return denyAdviceNl;
     }
+
+
+
+    public void setDenyAdvicePt(String denyAdvicePt) {
+        this.denyAdvicePt = denyAdvicePt;
+    }
+
+    public String getDenyAdvicePt() {
+        return denyAdvicePt;
+    }
+
+
 
     public int getNumberOfRevisions() {
         return numberOfRevisions;
@@ -338,7 +363,8 @@ public class PdpPolicyDefinition {
             Objects.equals(identityProviderIds, that.identityProviderIds) &&
             Objects.equals(attributes, that.attributes) &&
             Objects.equals(denyAdvice, that.denyAdvice) &&
-            Objects.equals(denyAdviceNl, that.denyAdviceNl);
+            Objects.equals(denyAdviceNl, that.denyAdviceNl) &&
+            Objects.equals(denyAdvicePt, that.denyAdvicePt);
     }
 
     @Override
@@ -356,6 +382,7 @@ public class PdpPolicyDefinition {
             ", attributes=" + attributes + "\n" +
             ", denyAdvice='" + denyAdvice + '\'' + "\n" +
             ", denyAdviceNl='" + denyAdviceNl + '\'' + "\n" +
+            ", denyAdvicePt='" + denyAdvicePt + '\'' + "\n" +
             ", denyRule=" + denyRule + "\n" +
             ", allAttributesMustMatch=" + allAttributesMustMatch + "\n" +
             '}';
@@ -382,4 +409,13 @@ public class PdpPolicyDefinition {
     public String getServiceProviderNameNl() {
         return serviceProviderNameNl;
     }
+
+    public void setServiceProviderNamePt(String serviceProviderNamePt) {
+        this.serviceProviderNamePt = serviceProviderNamePt;
+    }
+
+    public String getServiceProviderNamePt() {
+        return serviceProviderNamePt;
+    }
+
 }

--- a/pdp-server/src/main/resources/templates/policy-definition.xml
+++ b/pdp-server/src/main/resources/templates/policy-definition.xml
@@ -86,6 +86,12 @@
                             DataType="http://www.w3.org/2001/XMLSchema#string">{{denyAdviceNl}}</AttributeValue>
                 </AttributeAssignmentExpression>
                 <AttributeAssignmentExpression
+                        AttributeId="DenyMessage:pt"
+                        Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource">
+                    <AttributeValue
+                            DataType="http://www.w3.org/2001/XMLSchema#string">{{denyAdvicePt}}</AttributeValue>
+                </AttributeAssignmentExpression>
+                <AttributeAssignmentExpression
                     AttributeId="IdPOnly"
                     Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource">
                     <AttributeValue
@@ -119,6 +125,12 @@
                         Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource">
                     <AttributeValue
                             DataType="http://www.w3.org/2001/XMLSchema#string">{{denyAdviceNl}}</AttributeValue>
+                </AttributeAssignmentExpression>
+                <AttributeAssignmentExpression
+                        AttributeId="DenyMessage:pt"
+                        Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource">
+                    <AttributeValue
+                            DataType="http://www.w3.org/2001/XMLSchema#string">{{denyAdvicePt}}</AttributeValue>
                 </AttributeAssignmentExpression>
                 <AttributeAssignmentExpression
                     AttributeId="IdPOnly"

--- a/pdp-server/src/test/java/pdp/xacml/PolicyTemplateEngineTest.java
+++ b/pdp-server/src/test/java/pdp/xacml/PolicyTemplateEngineTest.java
@@ -26,6 +26,7 @@ public class PolicyTemplateEngineTest extends AbstractXacmlTest {
         definition.setDescription("The long description");
         definition.setDenyAdvice("Sorry, no access");
         definition.setDenyAdviceNl("Sorry, geen toegang");
+        definition.setDenyAdvicePt("Desculpe, não tem acesso");
         definition.setAttributes(Arrays.asList(
             new PdpAttribute("attr1", "value1"),
             new PdpAttribute("attr1", "value1a"),
@@ -68,3 +69,4 @@ public class PolicyTemplateEngineTest extends AbstractXacmlTest {
         assertEquals(fromPolicyXml, definition);
     }
 }
+

--- a/pdp-server/src/test/resources/policies/update_policy.json
+++ b/pdp-server/src/test/resources/policies/update_policy.json
@@ -19,6 +19,7 @@
   ],
   "denyAdvice": "asf",
   "denyAdviceNl": "asdf",
+  "denyAdvicePt": "asdfg",
   "denyRule": false,
   "allAttributesMustMatch": false,
   "userDisplayName": "admin",

--- a/pdp-server/src/test/resources/test-provisioned-policies/test.json
+++ b/pdp-server/src/test/resources/test-provisioned-policies/test.json
@@ -8,6 +8,7 @@
   }],
   "denyAdvice": "The message for the user",
   "denyAdviceNl": "De melding voor de gebruiker",
+  "denyAdvicePt": "A mensagem para o utilizador",
   "active": true,
   "type": "reg"
 }

--- a/pdp-server/src/test/resources/xacml/json-policies/policy_definition.json
+++ b/pdp-server/src/test/resources/xacml/json-policies/policy_definition.json
@@ -16,6 +16,7 @@
   "allAttributesMustMatch": false,
   "userDisplayName": "system",
   "denyAdviceNl": "Je bent geen lid van de SURF organisatie",
+  "denyAdvicePt": "Não é membro da organização SURF",
   "active": true,
   "type": "reg"
 }


### PR DESCRIPTION
In order to have the Authorization Policy in Dashboard working with PDP it was necessary to performed some changes on PDP server to have those messages saved on the database.
Even so, PDP and Dashboard are not 100% compatible with PT langue. The Portuguese **deny messages** are not shown when editing the **Policies**. We tried to made more changes but the PDP stability was fragile. So we are requesting only the changes we tested with success