### PR TITLE
typo: s/serviceProvicer/serviceProvider

### DIFF
--- a/src/main/java/pdp/stats/StatsContext.java
+++ b/src/main/java/pdp/stats/StatsContext.java
@@ -11,7 +11,7 @@ import java.util.Map;
 @Setter
 public class StatsContext {
 
-    private String serviceProvicer;
+    private String serviceProvider;
     private String identityProvider;
     private long responseTimeMs;
     private Map<String, Long> pipResponses = new HashMap<>();

--- a/src/main/java/pdp/stats/StatsContextHolder.java
+++ b/src/main/java/pdp/stats/StatsContextHolder.java
@@ -42,7 +42,7 @@ public class StatsContextHolder implements ServletRequestListener, JsonMapper {
     }
 
     private void saveContext(StatsContext context) {
-        if (context.getServiceProvicer() == null) {
+        if (context.getServiceProvider() == null) {
             return;
         }
         try {

--- a/src/main/java/pdp/web/PdpController.java
+++ b/src/main/java/pdp/web/PdpController.java
@@ -214,7 +214,7 @@ public class PdpController implements JsonMapper, IPAddressProvider {
                 .collect(singletonCollector());
         Collection<Attribute> attributes = req.getAttributes();
         stats.setIdentityProvider(getAttributeValue(attributes, "IDPentityID").orElse(""));
-        stats.setServiceProvicer(getAttributeValue(attributes, "SPentityID").orElse(""));
+        stats.setServiceProvider(getAttributeValue(attributes, "SPentityID").orElse(""));
     }
 
     private Optional<String> getAttributeValue(Collection<Attribute> attributes, String attributeId) {


### PR DESCRIPTION
This is showing in the decision-log:

```
analytics {"serviceProvicer":"urn:my:service","identityProvider":"https://myProvider.nl","responseTimeMs":1,"pipResponses":{},"decision":"Permit","loa":null,"policyId":"urn:surfconext:xacml:policy:id:myPolicy"}
```