### PR TITLE
Bugfix for syncing policy cache in multi-node env

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.openconext</groupId>
-    <version>7.4.0</version>
+    <version>7.5.0</version>
     <artifactId>pdp-server</artifactId>
     <packaging>jar</packaging>
     <name>pdp-server</name>

--- a/src/main/java/pdp/repositories/PdpPolicyPushVersionRepository.java
+++ b/src/main/java/pdp/repositories/PdpPolicyPushVersionRepository.java
@@ -14,7 +14,10 @@ public interface PdpPolicyPushVersionRepository extends CrudRepository<PdpPolicy
 
     @Transactional
     @Modifying
-    @Query(value = "UPDATE pdp_policy_push_version SET version = version + 1", nativeQuery = true)
+    @Query(value = "UPDATE pdp_policy_push_version SET version = version + 1 WHERE id = 1", nativeQuery = true)
     void incrementVersion();
+
+    @Query(value = "SELECT version FROM pdp_policy_push_version WHERE id = 1", nativeQuery = true)
+    Long getCurrentVersion();
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,12 +59,12 @@ policy:
 session-timeout: '28800'
 logging:
   level:
-    pdp: INFO
+    pdp: DEBUG
     org:
       springframework:
         security: WARN
       apache:
-        openaz: DEBUG
+        openaz: INFO
 endpoints:
   health:
     sensitive: 'false'


### PR DESCRIPTION
This commit fixes a bug, where after the in-memory policy cache version is permanently out of sync, the policies where refreshed in each call to the /decision endpoint